### PR TITLE
feat: verify Github webook signature and parse pull request events

### DIFF
--- a/github_webhook_handler/src/server.ts
+++ b/github_webhook_handler/src/server.ts
@@ -1,17 +1,54 @@
 import express from "express";
 import bodyParser from "body-parser";
 import dotenv from "dotenv";
+import crypto from "crypto"
 
 dotenv.config();
 
 const app = express();
 const PORT = process.env.PORT || 3000;
+const GITHUB_WEBHOOK_SECRET = process.env.GITHUB_WEBHOOK_SECRET || "";
 
 app.use(bodyParser.json());
 
+const verifySignature = (req: express.Request, res: express.Response, buf: Buffer) => {
+  const signature = req.headers["x-hub-signature-256"] as string;
+
+  if (!signature || !signature.startsWith("sha256=")) {
+    return res.status(401).send("Invalid signature");
+  }
+
+  const expectedSignature = "sha256=" + crypto
+    .createHmac("sha256", GITHUB_WEBHOOK_SECRET)
+    .update(buf)
+    .digest("hex");
+
+  if (!crypto.timingSafeEqual(Buffer.from(signature), Buffer.from(expectedSignature))) {
+    return res.status(401).send("Signature verification failed");
+  }
+};
+
+app.use(
+  bodyParser.json({
+    verify: verifySignature,
+  })
+);
+
 app.post("/webhook", (req, res) => {
-  console.log("🔹 Received Webhook:", JSON.stringify(req.body, null, 2));
-  res.status(200).send("Webhook received!");
+  const event = req.headers["x-github-event"];
+  const payload = req.body;
+
+  if (event === "pull_request") {
+    const { action, pull_request, repository } = payload;
+
+    console.log(`Received PR event: ${action}`);
+    console.log(`Repo: ${repository.full_name}`);
+    console.log(`PR Title: ${pull_request.title}`);
+    console.log(`Author: ${pull_request.user.login}`);
+    console.log(`PR URL: ${pull_request.html_url}`);
+  }
+
+  res.sendStatus(200);
 });
 
 app.listen(PORT, () => {


### PR DESCRIPTION
### Changes
- Parse the Github PR event and check it is valid (matches secret)
- If valid, print details of the PR event else return a `401`